### PR TITLE
Add support for Rails 7 and bump gem version

### DIFF
--- a/lib/country_state_select.rb
+++ b/lib/country_state_select.rb
@@ -61,7 +61,7 @@ module CountryStateSelect
 end
 
 case ::Rails.version.to_s
-when /[4-6]/
+when /^[4-7]./
   require 'country_state_select/engine'
 when /^3\.[12]/
   require 'country_state_select/engine3'

--- a/lib/country_state_select/version.rb
+++ b/lib/country_state_select/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CountryStateSelect
-  VERSION = '3.1.5'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
## Why? / What?
We are blocked from upgrading to Rails 7 by this gem. In order to make this gem compatible, the case statement for supported versions of Rails had to be updated.

I will submit a PR from this forked version back to the original repo. We can use this version while we wait for their approval.

### Screenshot(s)
NA
### JIRA Link
https://sentera.atlassian.net/browse/PAGC-794
## Migrations Required?
NA
## Data Recovery Strategy
NA
## QA Strategy
- [ ] Merge Latest Master
- [ ] Regression test forms that use country/state selectors
