### PR TITLE
Add support for Rails 8

### DIFF
--- a/lib/country_state_select.rb
+++ b/lib/country_state_select.rb
@@ -61,7 +61,7 @@ module CountryStateSelect
 end
 
 case ::Rails.version.to_s
-when /^[4-7]./
+when /^[4-8]./
   require 'country_state_select/engine'
 when /^3\.[12]/
   require 'country_state_select/engine3'

--- a/lib/country_state_select/version.rb
+++ b/lib/country_state_select/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CountryStateSelect
-  VERSION = '3.2.0'
+  VERSION = '3.3.0'
 end


### PR DESCRIPTION
We are blocked from upgrading to Rails 8 by this gem. In order to make this gem compatible, the case statement for supported versions of Rails had to be updated.

I will submit a PR from this forked version back to the original repo. We can use this version while we wait for their approval.
